### PR TITLE
Correct projection for omnisuite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 **/*.swp
 
 data/
-tmp/
+tmp*/
 
 **/__pycache__
 **/*.egg-info

--- a/omnisuite_examples/animator.py
+++ b/omnisuite_examples/animator.py
@@ -141,10 +141,10 @@ class PerlinNoiseAnimator(OmniSuiteWorldMapAnimator):
         """
         self._fig = plt.figure(figsize=self._config.figsize)
         self._ax = plt.axes(projection=self._config.projection)
+        # TODO: it seems the coastlines must be reducing the extent or something
+        # here since the natural earth PNG in the in material editor loads
+        # appropriately...
         self._ax.coastlines(linewidth=5, color="red")
-        # overlay natural earth to match projection
-        # self._ax.stock_img(alpha=0.5)
-        # self.
         base_map_image, base_map_extent, base_map_projection =\
             self._load_base_map()
         self._ax.imshow(
@@ -154,23 +154,23 @@ class PerlinNoiseAnimator(OmniSuiteWorldMapAnimator):
             origin='upper')
 
         # if you don't initialize the noise field, pcolormesh renders nothing
-        pdb.set_trace()
-        self._update_perlin_noise_field(0)
+        # pdb.set_trace()
+        # self._update_perlin_noise_field(0)
 
         # TODO: does pmesh correspond correctly to expected extent???
-        self._mesh = self._ax.pcolormesh(
-            self._grid.longitude,
-            self._grid.latitude,
-            self._perlin_noise_field,
-            transform=self._config.projection,
-            cmap="coolwarm"
-        )
+        # self._mesh = self._ax.pcolormesh(
+        # self._grid.longitude,
+        # self._grid.latitude,
+        # self._perlin_noise_field,
+        # transform=self._config.projection,
+        # cmap="coolwarm"
+        # )
 
         return
 
     def _update_frame(self, frame: int):
-        self._update_perlin_noise_field(frame)
-        self._mesh.set_array(self._perlin_noise_field.ravel())
+        # self._update_perlin_noise_field(frame)
+        # self._mesh.set_array(self._perlin_noise_field.ravel())
         return
 
     def _update_perlin_noise_field(self, frame: int):

--- a/omnisuite_examples/animator.py
+++ b/omnisuite_examples/animator.py
@@ -74,14 +74,7 @@ class OmniSuiteWorldMapAnimator(Animator):
         self._fig = plt.figure(figsize=self._config.figsize)
         self._ax = plt.axes(projection=self._config.projection)
         self._ax.coastlines()
-
         return
-
-    def _load_base_map(self):
-        img = plt.imread(self._config.base_map_path)
-        img_extent = (-180, 180, -90, 90)  # TODO: config for local area
-        img_proj = self._config.projection  # TODO: make config? prob not
-        return img, img_extent, img_proj
 
     def _update_and_save_frames(self):
         for frame in tqdm(
@@ -95,7 +88,7 @@ class OmniSuiteWorldMapAnimator(Animator):
         return
 
     def _update_frame(self, frame: int):
-        self._ax.text(0, frame, frame)  # arbitrary modification
+        self._ax.text(0, frame, frame)  # arbitrary modification needed for gif
         return
 
     def _open_frames(self) -> List[Image.Image]:
@@ -140,37 +133,28 @@ class PerlinNoiseAnimator(OmniSuiteWorldMapAnimator):
         [1]: https://gradsaddict.blogspot.com/2019/12/python-tutorial-blue-and-black-marble.html
         """
         self._fig = plt.figure(figsize=self._config.figsize)
-        self._ax = plt.axes(projection=self._config.projection)
-        # TODO: it seems the coastlines must be reducing the extent or something
-        # here since the natural earth PNG in the in material editor loads
-        # appropriately...
-        self._ax.coastlines(linewidth=5, color="red")
-        base_map_image, base_map_extent, base_map_projection =\
-            self._load_base_map()
-        self._ax.imshow(
-            base_map_image,
-            extent=base_map_extent,
-            transform=base_map_projection,
-            origin='upper')
+        rectangle_for_full_plot = [0, 0, 1, 1]  # Must for correct img size
+        self._ax = plt.axes(
+            rectangle_for_full_plot, projection=self._config.projection)
+        self._ax.coastlines()
+        self._ax.axis("off")
 
-        # if you don't initialize the noise field, pcolormesh renders nothing
-        # pdb.set_trace()
-        # self._update_perlin_noise_field(0)
+        # If you don't initialize the noise field, pcolormesh renders nothing
+        self._update_perlin_noise_field(0)
 
-        # TODO: does pmesh correspond correctly to expected extent???
-        # self._mesh = self._ax.pcolormesh(
-        # self._grid.longitude,
-        # self._grid.latitude,
-        # self._perlin_noise_field,
-        # transform=self._config.projection,
-        # cmap="coolwarm"
-        # )
+        self._mesh = self._ax.pcolormesh(
+            self._grid.longitude,
+            self._grid.latitude,
+            self._perlin_noise_field,
+            transform=self._config.projection,
+            cmap="coolwarm"
+        )
 
         return
 
     def _update_frame(self, frame: int):
-        # self._update_perlin_noise_field(frame)
-        # self._mesh.set_array(self._perlin_noise_field.ravel())
+        self._update_perlin_noise_field(frame)
+        self._mesh.set_array(self._perlin_noise_field.ravel())
         return
 
     def _update_perlin_noise_field(self, frame: int):

--- a/omnisuite_examples/animator.py
+++ b/omnisuite_examples/animator.py
@@ -74,7 +74,14 @@ class OmniSuiteWorldMapAnimator(Animator):
         self._fig = plt.figure(figsize=self._config.figsize)
         self._ax = plt.axes(projection=self._config.projection)
         self._ax.coastlines()
+
         return
+
+    def _load_base_map(self):
+        img = plt.imread(self._config.base_map_path)
+        img_extent = (-180, 180, -90, 90)  # TODO: config for local area
+        img_proj = self._config.projection  # TODO: make config? prob not
+        return img, img_extent, img_proj
 
     def _update_and_save_frames(self):
         for frame in tqdm(
@@ -127,13 +134,30 @@ class PerlinNoiseAnimator(OmniSuiteWorldMapAnimator):
         return
 
     def _plot_initial_frame(self):
+        """
+
+        References:
+        [1]: https://gradsaddict.blogspot.com/2019/12/python-tutorial-blue-and-black-marble.html
+        """
         self._fig = plt.figure(figsize=self._config.figsize)
         self._ax = plt.axes(projection=self._config.projection)
-        self._ax.coastlines()
+        self._ax.coastlines(linewidth=5, color="red")
+        # overlay natural earth to match projection
+        # self._ax.stock_img(alpha=0.5)
+        # self.
+        base_map_image, base_map_extent, base_map_projection =\
+            self._load_base_map()
+        self._ax.imshow(
+            base_map_image,
+            extent=base_map_extent,
+            transform=base_map_projection,
+            origin='upper')
 
         # if you don't initialize the noise field, pcolormesh renders nothing
+        pdb.set_trace()
         self._update_perlin_noise_field(0)
 
+        # TODO: does pmesh correspond correctly to expected extent???
         self._mesh = self._ax.pcolormesh(
             self._grid.longitude,
             self._grid.latitude,
@@ -141,6 +165,7 @@ class PerlinNoiseAnimator(OmniSuiteWorldMapAnimator):
             transform=self._config.projection,
             cmap="coolwarm"
         )
+
         return
 
     def _update_frame(self, frame: int):

--- a/omnisuite_examples/animator_config.py
+++ b/omnisuite_examples/animator_config.py
@@ -55,7 +55,11 @@ class OmniSuiteAnimatorConfig(AnimatorConfig):
 
     projection: Projection = PlateCarree()
 
+    # TODO: better default
+    base_map_path: str = "tmp/tutorial_Story_Creation_Basics/natural_earth.png"
+
     def __post_init__(self):
+        super().__post_init__()
         if self.figsize is None:
             self.figsize = (
                 self.plot_width_in_pixels*AnimatorConfig.INCH_PER_PIXEL,

--- a/omnisuite_examples/animator_config.py
+++ b/omnisuite_examples/animator_config.py
@@ -2,7 +2,7 @@ from cartopy.crs import Projection, PlateCarree
 from dataclasses import dataclass
 from matplotlib.pyplot import rcParams
 from os.path import exists, join
-from typing import ClassVar, Tuple, Dict
+from typing import ClassVar, Tuple, Optional
 
 
 @dataclass
@@ -49,11 +49,14 @@ class AnimatorConfig:
 class OmniSuiteAnimatorConfig(AnimatorConfig):
     plot_width_in_pixels: int = 4096
     plot_height_in_pixels: int = 2048
-    figsize: Tuple[int, int] = (
-        plot_width_in_pixels*AnimatorConfig.INCH_PER_PIXEL,
-        plot_height_in_pixels*AnimatorConfig.INCH_PER_PIXEL)
-
+    figsize: Optional[Tuple[int, int]] = None
     pil_image_gif_loop: int = 0
     pil_image_duration_between_frames_in_ms: float = 500
 
     projection: Projection = PlateCarree()
+
+    def __post_init__(self):
+        if self.figsize is None:
+            self.figsize = (
+                self.plot_width_in_pixels*AnimatorConfig.INCH_PER_PIXEL,
+                self.plot_height_in_pixels*AnimatorConfig.INCH_PER_PIXEL)

--- a/scripts/plot_timelapsed_perlin_noise_on_latlon_grid.py
+++ b/scripts/plot_timelapsed_perlin_noise_on_latlon_grid.py
@@ -50,21 +50,21 @@ def cli():
     parser.add_argument(
         "--save-animation", action=BooleanOptionalAction, default=False)
 
-    default_plot_width_in_pixels = 4096
+    default_plot_width_in_pixels = 2048
     parser.add_argument(
         "--plot_width_in_pixels",
         type=int,
         help=f" (default: {default_plot_width_in_pixels})",
         default=default_plot_width_in_pixels)
 
-    default_plot_height_in_pixels = 2048
+    default_plot_height_in_pixels = 1024
     parser.add_argument(
         "--plot_height_in_pixels",
         type=int,
         help=f" (default: {default_plot_height_in_pixels})",
         default=default_plot_height_in_pixels)
 
-    default_num_frames_in_animation = 10
+    default_num_frames_in_animation = 3
     parser.add_argument(
         "--num_frames_in_animation",
         help=f"default: {default_num_frames_in_animation}",

--- a/scripts/plot_timelapsed_perlin_noise_on_latlon_grid.py
+++ b/scripts/plot_timelapsed_perlin_noise_on_latlon_grid.py
@@ -64,7 +64,7 @@ def cli():
         help=f" (default: {default_plot_height_in_pixels})",
         default=default_plot_height_in_pixels)
 
-    default_num_frames_in_animation = 366
+    default_num_frames_in_animation = 10
     parser.add_argument(
         "--num_frames_in_animation",
         help=f"default: {default_num_frames_in_animation}",

--- a/scripts/plot_timelapsed_perlin_noise_on_latlon_grid.py
+++ b/scripts/plot_timelapsed_perlin_noise_on_latlon_grid.py
@@ -52,21 +52,21 @@ def cli():
 
     default_plot_width_in_pixels = 2048
     parser.add_argument(
-        "--plot_width_in_pixels",
+        "-W", "--plot_width_in_pixels",
         type=int,
         help=f" (default: {default_plot_width_in_pixels})",
         default=default_plot_width_in_pixels)
 
     default_plot_height_in_pixels = 1024
     parser.add_argument(
-        "--plot_height_in_pixels",
+        "-H", "--plot_height_in_pixels",
         type=int,
         help=f" (default: {default_plot_height_in_pixels})",
         default=default_plot_height_in_pixels)
 
     default_num_frames_in_animation = 3
     parser.add_argument(
-        "--num_frames_in_animation",
+        "-n", "--num_frames_in_animation",
         help=f"default: {default_num_frames_in_animation}",
         type=int,
         default=default_num_frames_in_animation)

--- a/tests/test_omnisuite_world_map_animator.py
+++ b/tests/test_omnisuite_world_map_animator.py
@@ -27,11 +27,6 @@ class TestOmniSuiteWorldMapAnimator(AnimatorTestMixin, unittest.TestCase):
         return omnisuite_world_map_animator
 
     def assert_animate(self):
-        """
-
-        An animation was successful when the number of frames in saved
-        animation (e.g., gif) matches the expected amount of frames.
-        """
         with Image.open(self._config.path_to_save_animation) as gif:
             n_frames_in_gif = gif.n_frames
             self.assertEqual(n_frames_in_gif, self.num_frames_in_animation)


### PR DESCRIPTION
Resolves https://github.com/jfdev001/omnisuite-examples/issues/3

By ensuring that plt.axes has a rectangle corresponding to the entire span of the image (i.e., [0, 0, 1, 1]). Without this, the default rectangle is less than the entire span of the image (i.e., with resolution e.g., 2048x1024) and the resulting image is not rendered correctly with omnisuite.